### PR TITLE
resolving error in `nmea_parse_checksum()` 

### DIFF
--- a/R/nmea-checksum.R
+++ b/R/nmea-checksum.R
@@ -28,6 +28,6 @@
 #'
 nmea_parse_checksum <- function(x) {
   x <- as_nmea(x)
-  result <- .Call(`_nmea_c_checksum`, x) 
+  result <- .Call(`nmea_c_checksum`, x) 
   tibble::new_tibble(result, nrow = length(x))
 }

--- a/R/nmea-checksum.R
+++ b/R/nmea-checksum.R
@@ -28,6 +28,6 @@
 #'
 nmea_parse_checksum <- function(x) {
   x <- as_nmea(x)
-  result <- .Call("nmea_c_checksum", x)
+  result <- .Call(`_nmea_c_checksum`, x) 
   tibble::new_tibble(result, nrow = length(x))
 }

--- a/R/nmea.R
+++ b/R/nmea.R
@@ -65,7 +65,7 @@ as_nmea.raw <- function(x, ...) {
 #' @rdname nmea
 #' @export
 as_nmea.character <- function(x, ...) {
-  new_nmea(.Call(nmea_c_character_as_nmea, x))
+  new_nmea(.Call(nmea_c_character_as_nmea, x)) #is this use of .Call ok?
 }
 
 

--- a/R/nmea.R
+++ b/R/nmea.R
@@ -65,7 +65,7 @@ as_nmea.raw <- function(x, ...) {
 #' @rdname nmea
 #' @export
 as_nmea.character <- function(x, ...) {
-  new_nmea(.Call(nmea_c_character_as_nmea, x)) #is this use of .Call ok?
+  new_nmea(.Call(nmea_c_character_as_nmea, x)) #should be `_nmea_cpp_nmea_as_character`?
 }
 
 

--- a/R/nmea.R
+++ b/R/nmea.R
@@ -65,7 +65,7 @@ as_nmea.raw <- function(x, ...) {
 #' @rdname nmea
 #' @export
 as_nmea.character <- function(x, ...) {
-  new_nmea(.Call(nmea_c_character_as_nmea, x)) #should be `_nmea_cpp_nmea_as_character`?
+  new_nmea(.Call(nmea_c_character_as_nmea, x)) 
 }
 
 


### PR DESCRIPTION
Fixed (I think) error in Ln31 of R/nmea-checksum.R (problem with .Call() throwing a "DLL requires the use of native symbols" error). 